### PR TITLE
Various buildscript fixes for Alpine Docker

### DIFF
--- a/build-chroot.sh
+++ b/build-chroot.sh
@@ -165,15 +165,12 @@ cd ..
 # libcap Build
 tar xf ../sources/libcap-*.tar*
 cd libcap-*/
-# NOTE: For some reason, libcap hardcodes gcc as the compiler, so we need to
-#       modify the Makefile to set it to clang. ~ahill
-sed -i "s/CC :=.*/CC := clang/" Make.Rules
 # NOTE: When trying to figure out where to put libraries, libcap attempts to
 #       invoke ldd, which is not a valid command at this point. As a result, it
 #       dumps the libraries into the root of the filesystem. ~ahill
 sed -i "s/^lib=.*/lib=\/lib/" Make.Rules
 # FIXME: libcap's pkgconf file claims to be installed under / rather than /lib. ~ahill
-make -j $THREADS
+make CC=clang -j $THREADS
 make -j $THREADS install
 cd ..
 

--- a/build-chroot.sh
+++ b/build-chroot.sh
@@ -165,13 +165,9 @@ cd ..
 # libcap Build
 tar xf ../sources/libcap-*.tar*
 cd libcap-*/
-# NOTE: When trying to figure out where to put libraries, libcap attempts to
-#       invoke ldd, which is not a valid command at this point. As a result, it
-#       dumps the libraries into the root of the filesystem. ~ahill
-sed -i "s/^lib=.*/lib=\/lib/" Make.Rules
-# FIXME: libcap's pkgconf file claims to be installed under / rather than /lib. ~ahill
-make CC=clang -j $THREADS
-make -j $THREADS install
+# NOTE: Review additional prefix settings for correctness
+make CC=clang prefix=/usr lib=lib -j $THREADS
+make prefix=/usr lib=lib -j $THREADS install
 cd ..
 
 # Linux PAM Build

--- a/build.sh
+++ b/build.sh
@@ -272,6 +272,7 @@ make -j $THREAD
 make -j $THREAD install DESTDIR=$MAPLE
 cd ..
 
+# Clear compiler flags to avoid potentially issues with the LLVM build
 export CFLAGS=""
 export CXXFLAGS=""
 


### PR DESCRIPTION
This PR contains some small fixes to ensure compilation on a minimal alpine docker image:

## `build.sh`
- Compile llvm stage 1 and stage 2 in separate directories to allow easier incremental builds
- Disable forcing LLD on stage 1 as a minimal alpine image fails to find LLD via `-fuse-ld=lld`
- Add `CMAKE_BUILD_WITH_INSTALL_RPATH` to avoid issues in situations where CMake elf patching is disabled
## `build-chroot.sh`
- Set the `CC` variable as passed to make instead of modifying the Makefile

## Minimal dependencies required (alpine names):
```
llvm clang lld python3 rsync linux-headers ninja cmake make ccache llvm-libunwind libc++ meson
```